### PR TITLE
fix: pie build flag so it can be linked using gcc

### DIFF
--- a/make_settings/settings.mk
+++ b/make_settings/settings.mk
@@ -3,7 +3,7 @@ SETTINGS_MK = 1
 
 NAME	= libkm.a
 
-CFLAGS	= -Wall -Wextra -Werror -pedantic -O3
+CFLAGS	= -Wall -Wextra -Werror -pedantic -O3 -fpie
 IFLAGS	= -I$(IDIR)
 
 SDIR	= src


### PR DESCRIPTION
On linux linking using gcc would not work because of position dependant code in the printf implementation [here](https://github.com/K1ngmar/libkm/blob/main/src/stdio/printf/printf.c#L50). Using the -fpie flag makes the code position independent so it can be linked later on. 🦖 